### PR TITLE
Fix typo in find_processor_info description

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1354,7 +1354,7 @@ def getsha256hash(filepath):
 
 
 def find_processor_path(processor_name, recipe, env=None):
-    """Returns the pathname to a procesor given a name and a recipe"""
+    """Returns the pathname to a processor given a name and a recipe"""
     if env is None:
         env = {}
         env["RECIPE_SEARCH_DIRS"] = get_pref("RECIPE_SEARCH_DIRS") or []


### PR DESCRIPTION
The word "processor" in the description for find_processor_info (autopkg core code) is short one "s".

If you want tests to show that fixing this typo does not affect the code, please advise.